### PR TITLE
Clean up dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.49</version>
+    <version>3.50</version>
     <relativePath />
   </parent>
 
@@ -67,32 +67,29 @@
   </pluginRepositories>
 
   <dependencies>
-      <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
-      <dependency>
+    <!-- FIXME Use org.apache.maven.shared.utils.io.DirectoryScanner, but really should use hudson.util.DirScanner -->
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.1.0</version>
+      <exclusions>
+        <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
-          <version>2.5</version>
-      </dependency>
-      <!-- https://mvnrepository.com/artifact/org.apache.maven.shared/maven-shared-utils -->
-      <dependency>
-          <groupId>org.apache.maven.shared</groupId>
-          <artifactId>maven-shared-utils</artifactId>
-          <version>3.1.0</version>
-      </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>2.1</version>
+          <!-- provided by core -->
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-core</artifactId>
-      <version>1.7.0</version>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>sshd</artifactId>
+      <version>2.6</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml</groupId>
-      <artifactId>jackson-xml-databind</artifactId>
-      <version>0.6.2</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.owasp.encoder</groupId>
@@ -103,6 +100,7 @@
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
       <artifactId>owasp-java-html-sanitizer</artifactId>
       <version>20190503.1</version>
+      <!-- has guava 27.1, conflicts with 11.0.1 provided by core -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/electricflow/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/Utils.java
@@ -14,6 +14,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.EnvVars;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
@@ -23,7 +24,6 @@ import jenkins.model.Jenkins;
 import org.apache.commons.logging.Log;
 
 import org.apache.commons.logging.LogFactory;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;


### PR DESCRIPTION
* Update parent POM
* notes on maven-shared-utils: ideally it should be removed in favor of Jenkins utils
* Remove plexus-utils (unused afaics)
* Replace sshd-core by dependency on the sshd module that is shipped with core
* Replace direct dependency on old jackson by dependency on jackson2-api lib plugin

Noting that owasp-java-html-sanitizer brings a guava version (27.1) that
is incompatible with the one shipped with jenkins core (11.0.1).

These changes reduces the package size by 50%