### PR TITLE
JCasC compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,5 +113,20 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.0</version>
     <relativePath />
   </parent>
 
@@ -14,15 +14,8 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.222.1</jenkins.version>
     <java.level>8</java.level>
-    <!-- Jenkins Test Harness version you use to test the plugin. -->
-    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <!--<jenkins-test-harness.version>2.13</jenkins-test-harness.version>-->
-    <!-- Other properties you may want to use:
-         ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-         ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-    -->
   </properties>
 
   <name>CloudBees Flow</name>
@@ -66,19 +59,27 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>9</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
-      <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
-      <dependency>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-          <version>2.5</version>
-      </dependency>
-      <!-- https://mvnrepository.com/artifact/org.apache.maven.shared/maven-shared-utils -->
-      <dependency>
-          <groupId>org.apache.maven.shared</groupId>
-          <artifactId>maven-shared-utils</artifactId>
-          <version>3.1.0</version>
-      </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.1.0</version>
+    </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
@@ -107,13 +108,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.22</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.3.1</version>
     </dependency>
-
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.222.1</jenkins.version>
+    <jenkins.version>2.190.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -63,7 +63,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
+        <artifactId>bom-2.190.x</artifactId>
         <version>9</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.190.1</jenkins.version>
+    <jenkins.version>2.190.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
@@ -45,18 +45,6 @@ public class Configuration
 
     //~ Constructors -----------------------------------------------------------
 
-    @Deprecated
-    public Configuration(
-          String configurationName,
-          String electricFlowUrl,
-          String electricFlowUser,
-          String electricFlowPassword,
-          String electricFlowApiVersion,
-          boolean ignoreSslConnectionErrors)
-    {
-        this(configurationName, electricFlowUrl, electricFlowUser, Secret.fromString(electricFlowPassword), electricFlowApiVersion, ignoreSslConnectionErrors);
-    }
-
     @DataBoundConstructor public Configuration(
             String configurationName,
             String electricFlowUrl,

--- a/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
@@ -26,6 +26,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+import sun.nio.ch.Secrets;
 
 /**
  * Configuration to access ElectricFlow server.
@@ -38,39 +39,38 @@ public class Configuration
 
     private final String configurationName;
     private final String electricFlowUser;
-    private final String electricFlowPassword;
+    private final Secret electricFlowPassword;
     private final String electricFlowUrl;
     private final String electricFlowApiVersion;
     private final boolean ignoreSslConnectionErrors;
 
     //~ Constructors -----------------------------------------------------------
 
+    @Deprecated
+    public Configuration(
+          String configurationName,
+          String electricFlowUrl,
+          String electricFlowUser,
+          String electricFlowPassword,
+          String electricFlowApiVersion,
+          boolean ignoreSslConnectionErrors)
+    {
+        this(configurationName, electricFlowUrl, electricFlowUser, Secret.fromString(electricFlowPassword), electricFlowApiVersion, ignoreSslConnectionErrors);
+    }
+
     @DataBoundConstructor public Configuration(
             String configurationName,
             String electricFlowUrl,
             String electricFlowUser,
-            String electricFlowPassword,
+            Secret electricFlowPassword,
             String electricFlowApiVersion,
             boolean ignoreSslConnectionErrors)
     {
         this.configurationName = configurationName;
         this.electricFlowUrl   = electricFlowUrl;
         this.electricFlowUser  = electricFlowUser;
-
-        if (!electricFlowPassword.equals(this.getElectricFlowPassword())) {
-
-            // encrypted one
-            Secret secret = Secret.fromString(electricFlowPassword);
-
-            this.electricFlowPassword = secret.getEncryptedValue();
-        }
-        else {
-            this.electricFlowPassword = electricFlowPassword;
-        }
-
-        // end
+        this.electricFlowPassword = electricFlowPassword;
         this.electricFlowApiVersion = electricFlowApiVersion;
-
         this.ignoreSslConnectionErrors = ignoreSslConnectionErrors;
     }
 
@@ -91,7 +91,7 @@ public class Configuration
         return this.ignoreSslConnectionErrors;
     }
 
-    public String getElectricFlowPassword()
+    public Secret getElectricFlowPassword()
     {
         return this.electricFlowPassword;
     }

--- a/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
@@ -117,7 +117,7 @@ public class Configuration
         public FormValidation doCheckConfigurationName(
                 @QueryParameter String value)
         {
-            if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
 
@@ -127,7 +127,7 @@ public class Configuration
         public FormValidation doCheckElectricFlowApiVersion(
                 @QueryParameter String value)
         {
-            if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
 
@@ -138,7 +138,7 @@ public class Configuration
         public FormValidation doCheckElectricFlowPassword(
                 @QueryParameter String value)
         {
-            if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
 
@@ -148,7 +148,7 @@ public class Configuration
         public FormValidation doCheckElectricFlowUrl(
                 @QueryParameter String value)
         {
-            if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
 
@@ -158,7 +158,7 @@ public class Configuration
         public FormValidation doCheckElectricFlowUser(
                 @QueryParameter String value)
         {
-            if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
 
@@ -167,7 +167,7 @@ public class Configuration
 
         public ListBoxModel doFillElectricFlowApiVersionItems()
         {
-            if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return new ListBoxModel();
             }
 
@@ -188,7 +188,7 @@ public class Configuration
                 @QueryParameter("ignoreSslConnectionErrors") final boolean ignoreSslConnectionErrors)
             throws IOException
         {
-            if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
 

--- a/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/Configuration.java
@@ -26,7 +26,6 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import org.kohsuke.stapler.interceptor.RequirePOST;
-import sun.nio.ch.Secrets;
 
 /**
  * Configuration to access ElectricFlow server.

--- a/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowClient.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowClient.java
@@ -77,8 +77,7 @@ public class ElectricFlowClient
         if (cred != null) {
             electricFlowUrl = cred.getElectricFlowUrl();
             userName        = cred.getElectricFlowUser();
-            password        = Secret.fromString(cred.getElectricFlowPassword())
-                                    .getPlainText();
+            password        = cred.getElectricFlowPassword().getPlainText();
             ignoreSslConnectionErrors = cred.getIgnoreSslConnectionErrors();
 
             String electricFlowApiVersion = cred.getElectricFlowApiVersion();

--- a/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowGlobalConfiguration.java
@@ -11,6 +11,8 @@ package org.jenkinsci.plugins.electricflow;
 
 import java.util.List;
 
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import net.sf.json.JSONObject;
@@ -19,13 +21,14 @@ import hudson.Extension;
 
 import jenkins.model.GlobalConfiguration;
 
-@Extension public class ElectricFlowGlobalConfiguration
+@Extension @Symbol("electricflow") public class ElectricFlowGlobalConfiguration
     extends GlobalConfiguration
 {
 
     //~ Instance fields --------------------------------------------------------
 
-    public List<Configuration> efConfigurations;
+    @Deprecated private transient List<Configuration> efConfigurations;
+    public List<Configuration> configurations;
 
     //~ Constructors -----------------------------------------------------------
 
@@ -41,8 +44,8 @@ import jenkins.model.GlobalConfiguration;
             JSONObject     formData)
         throws FormException
     {
-        this.efConfigurations = req.bindJSONToList(Configuration.class,
-                formData.get("configurations"));
+        this.configurations = null;
+        req.bindJSON(this, formData);
         save();
 
         return true;
@@ -50,6 +53,23 @@ import jenkins.model.GlobalConfiguration;
 
     public List<Configuration> getConfigurations()
     {
-        return this.efConfigurations;
+        return this.configurations;
+    }
+
+    @DataBoundSetter public void setConfigurations(List<Configuration> configurations)
+    {
+        this.configurations = configurations;
+    }
+
+    /*
+    * This is required to transform the old efConfigurations to the new configurations
+    */
+    private Object readResolve()
+    {
+        if (efConfigurations != null)
+        {
+            this.configurations = efConfigurations;
+        }
+        return this;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/electricflow/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/Utils.java
@@ -193,8 +193,8 @@ public class Utils
                                                                   .get(
                                                                       ElectricFlowGlobalConfiguration.class);
 
-        if (cred != null && cred.efConfigurations != null) {
-            return cred.efConfigurations;
+        if (cred != null && cred.configurations != null) {
+            return cred.configurations;
         }
 
         return new ArrayList<>();

--- a/src/main/java/org/jenkinsci/plugins/electricflow/factories/ElectricFlowClientFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/factories/ElectricFlowClientFactory.java
@@ -56,14 +56,13 @@ public class ElectricFlowClientFactory {
         String password;
         if (overrideCredential == null) {
             username = cred.getElectricFlowUser();
-            password = Secret.fromString(cred.getElectricFlowPassword())
-                    .getPlainText();
+            password = cred.getElectricFlowPassword().getPlainText();
         } else {
             StandardUsernamePasswordCredentials creds = overrideCredential.getUsernamePasswordBasedOnCredentialId(envReplacer, run);
             if (creds == null) {
                 if (ignoreUnresolvedOverrideCredential) {
                     username = cred.getElectricFlowUser();
-                    password = Secret.fromString(cred.getElectricFlowPassword())
+                    password = cred.getElectricFlowPassword()
                             .getPlainText();
                 } else {
                     throw new RuntimeException("Override credentials are not found by provided credential id");

--- a/src/test/java/BasicUnitTestsWithJenkins.java
+++ b/src/test/java/BasicUnitTestsWithJenkins.java
@@ -3,6 +3,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
+import hudson.util.Secret;
 import org.jenkinsci.plugins.electricflow.Configuration;
 import org.jenkinsci.plugins.electricflow.ElectricFlowGlobalConfiguration;
 import org.junit.ClassRule;
@@ -43,7 +44,7 @@ public class BasicUnitTestsWithJenkins {
         Configuration configuration = new Configuration(FLOW_CONFIG_NAME,
                 FLOW_ENDPOINT,
                 FLOW_USER,
-                FLOW_PASSWORD,
+                Secret.fromString(FLOW_PASSWORD),
                 FLOW_REST_API_URI_PATH,
                 true);
 

--- a/src/test/java/BasicUnitTestsWithJenkins.java
+++ b/src/test/java/BasicUnitTestsWithJenkins.java
@@ -12,6 +12,7 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.LinkedList;
@@ -37,7 +38,7 @@ public class BasicUnitTestsWithJenkins {
     public void getConfigurationByDescriptor() {
         ElectricFlowGlobalConfiguration electricFlowGlobalConfiguration = (ElectricFlowGlobalConfiguration) jenkinsRule.getInstance().getDescriptorByName("org.jenkinsci.plugins.electricflow.ElectricFlowGlobalConfiguration");
 
-        electricFlowGlobalConfiguration.efConfigurations = new LinkedList<>();
+        electricFlowGlobalConfiguration.configurations = new LinkedList<>();
 
         Configuration configuration = new Configuration(FLOW_CONFIG_NAME,
                 FLOW_ENDPOINT,
@@ -46,7 +47,7 @@ public class BasicUnitTestsWithJenkins {
                 FLOW_REST_API_URI_PATH,
                 true);
 
-        electricFlowGlobalConfiguration.efConfigurations.add(configuration);
+        electricFlowGlobalConfiguration.configurations.add(configuration);
         electricFlowGlobalConfiguration.save();
 
         assertTrue(electricFlowGlobalConfiguration.getConfigurations().size() == 1);

--- a/src/test/java/org/jenkinsci/plugins/electricflow/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/electricflow/ConfigurationAsCodeTest.java
@@ -1,18 +1,12 @@
 package org.jenkinsci.plugins.electricflow;
 
 import hudson.ExtensionList;
-import io.jenkins.plugins.casc.ConfigurationContext;
-import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import io.jenkins.plugins.casc.misc.Util;
-import io.jenkins.plugins.casc.model.CNode;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/org/jenkinsci/plugins/electricflow/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/electricflow/ConfigurationAsCodeTest.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.electricflow;
+
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.Util;
+import io.jenkins.plugins.casc.model.CNode;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurationAsCodeTest {
+    @Rule
+    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("casc/configuration-as-code.yml")
+    public void shouldBeAbleToAcceptConfiguration() {
+        final ElectricFlowGlobalConfiguration electricFlowGlobalConfiguration = ExtensionList.lookupSingleton(ElectricFlowGlobalConfiguration.class);
+        assertNotNull(electricFlowGlobalConfiguration);
+
+        final List<Configuration> configurations = electricFlowGlobalConfiguration.getConfigurations();
+        assertThat(configurations, Matchers.iterableWithSize(1));
+
+        final Configuration configuration = configurations.get(0);
+        assertEquals("this is the first configuration", configuration.getConfigurationName());
+        assertEquals("test", configuration.getElectricFlowUser());
+        assertThat(configuration.getElectricFlowPassword(), Matchers.notNullValue());
+        assertEquals("https://test-url/", configuration.getElectricFlowUrl());
+        assertEquals("/rest/v1.0", configuration.getElectricFlowApiVersion());
+        assertTrue(configuration.getIgnoreSslConnectionErrors());
+    }
+}

--- a/src/test/resources/casc/configuration-as-code.yml
+++ b/src/test/resources/casc/configuration-as-code.yml
@@ -1,0 +1,9 @@
+unclassified:
+  electricflow:
+    configurations:
+      - configurationName: "this is the first configuration"
+        electricFlowUser: "test"
+        electricFlowPassword: "{THIS_IS_NOT_A_CORRECT_PASSWORD}"
+        electricFlowUrl: "https://test-url/"
+        electricFlowApiVersion: "/rest/v1.0"
+        ignoreSslConnectionErrors: true


### PR DESCRIPTION
This PR transform the `configurations` from the Global Settings to ease the JCasC namings. However, I normally took care of the old format transformation.

I couldn't validate the export with an unit test, because the `Secret` as a different value each time. 

It would be great to transform the `Secret` to an actual `Credentials` so that external credentials provider could also be used. 