### PR TITLE
Exclude guava from transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>30.1-jre</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>30.1-jre</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -111,6 +106,12 @@
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
       <artifactId>owasp-java-html-sanitizer</artifactId>
       <version>20190503.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -158,8 +159,8 @@
       <version>2.12</version>
       <type>hpi</type>
       <optional>true</optional>
-  </dependency>
-  <dependency>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Guava requires to be updated because of a CVE (https://nvd.nist.gov/vuln/detail/CVE-2020-8908). Guava is not a direct dependency of the plugin but is pulled through `com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
