### PR TITLE
[BEE-2918] Expose `CloudBeesCDPBABuildDetails` in Jenkins REST API and mirror `EFCause` data to `CloudBeesCDPBABuildDetails`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/electricflow/ArtifactUploadSummaryTextAction.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/ArtifactUploadSummaryTextAction.java
@@ -4,7 +4,10 @@ import hudson.model.Run;
 import java.util.ArrayList;
 import java.util.List;
 import org.jenkinsci.plugins.electricflow.extension.ArtifactUploadData;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
+@ExportedBean
 public class ArtifactUploadSummaryTextAction extends SummaryTextAction {
 
   private ArtifactUploadData artifactUploadData;
@@ -18,6 +21,7 @@ public class ArtifactUploadSummaryTextAction extends SummaryTextAction {
     this.projectActions = projectActions;
   }
 
+  @Exported
   public ArtifactUploadData getArtifactUploadData() {
     return artifactUploadData;
   }

--- a/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisher.java
@@ -55,6 +55,7 @@ import org.jenkinsci.plugins.electricflow.exceptions.FlowRuntimeException;
 import org.jenkinsci.plugins.electricflow.factories.ElectricFlowClientFactory;
 import org.jenkinsci.plugins.electricflow.models.CIBuildDetail;
 import org.jenkinsci.plugins.electricflow.models.CIBuildDetail.BuildAssociationType;
+import org.jenkinsci.plugins.electricflow.models.CIBuildDetail.BuildTriggerSource;
 import org.jenkinsci.plugins.electricflow.models.cdrestdata.jobs.GetPipelineRuntimeDetailsResponseData;
 import org.jenkinsci.plugins.electricflow.ui.FieldValidationStatus;
 import org.jenkinsci.plugins.electricflow.ui.HtmlUtils;
@@ -203,7 +204,7 @@ public class ElectricFlowPipelinePublisher extends Recorder implements SimpleBui
                 projectName,
                 null,
                 null,
-                null,
+                BuildTriggerSource.CI,
                 BuildAssociationType.TRIGGERED_BY_CI
         );
       } catch (RuntimeException exception) {

--- a/src/main/java/org/jenkinsci/plugins/electricflow/action/CloudBeesCDPBABuildDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/action/CloudBeesCDPBABuildDetails.java
@@ -8,8 +8,10 @@ import org.jenkinsci.plugins.electricflow.Credential;
 import org.jenkinsci.plugins.electricflow.causes.EFCause;
 import org.jenkinsci.plugins.electricflow.models.CIBuildDetail;
 import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 // TODO: Since we have now 2 classes that are doing pretty match the same
+@ExportedBean
 public class CloudBeesCDPBABuildDetails implements Action {
   @Exported public String flowRuntimeId = "";
   @Exported public String projectName = "";

--- a/src/main/java/org/jenkinsci/plugins/electricflow/extension/ArtifactUploadData.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/extension/ArtifactUploadData.java
@@ -1,5 +1,9 @@
 package org.jenkinsci.plugins.electricflow.extension;
 
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+@ExportedBean
 public class ArtifactUploadData {
 
   // ~ Instance fields --------------------------------------------------------
@@ -14,6 +18,7 @@ public class ArtifactUploadData {
 
   // ~ Methods ----------------------------------------------------------------
 
+  @Exported
   public String getArtifactName() {
     return artifactName;
   }
@@ -22,6 +27,7 @@ public class ArtifactUploadData {
     this.artifactName = artifactName;
   }
 
+  @Exported
   public String getArtifactVersion() {
     return artifactVersion;
   }
@@ -30,6 +36,7 @@ public class ArtifactUploadData {
     this.artifactVersion = artifactVersion;
   }
 
+  @Exported
   public String getArtifactVersionName() {
     return artifactVersionName;
   }
@@ -38,6 +45,7 @@ public class ArtifactUploadData {
     this.artifactVersionName = artifactVersionName;
   }
 
+  @Exported
   public String getArtifactUrl() {
     return artifactUrl;
   }
@@ -46,6 +54,7 @@ public class ArtifactUploadData {
     this.artifactUrl = artifactUrl;
   }
 
+  @Exported
   public String getRepositoryName() {
     return repositoryName;
   }
@@ -54,6 +63,7 @@ public class ArtifactUploadData {
     this.repositoryName = repositoryName;
   }
 
+  @Exported
   public String getRepositoryType() {
     return repositoryType;
   }
@@ -62,6 +72,7 @@ public class ArtifactUploadData {
     this.repositoryType = repositoryType;
   }
 
+  @Exported
   public String getFilePath() {
     return filePath;
   }


### PR DESCRIPTION
This PR makes it so that the `CloudBeesCDPBABuildDetails` action added to builds by this plugin is exported in the Jenkins read-only REST API. It also makes it so that the data stored in `EFCause` for CI builds triggered by CD is stored as an `CloudBeesCDPBABuildDetails` action on the build so that all CD-related associations can be obtained from the REST API in a unified way.

This PR also exposes the data in `ArtifactUploadSummaryTextAction` that contains data about artifacts uploaded to CD in the Jenkins read only REST API.

I am not sure if there is a way to add automated tests for these changes. I could add some tests using `WireMock` or something like that but it doesn't look like there are any existing tests that do that kind of thing.

CC @sureshmurthy85 @justnoxx 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
