### PR TITLE
Rebranding: Update code to use new triggerSource and associationType enum values

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/electricflow/event/ElectricFlowBuildWatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/event/ElectricFlowBuildWatcher.java
@@ -105,8 +105,8 @@ public class ElectricFlowBuildWatcher extends RunListener<Run> {
       if (efCause != null) {
         details = new CIBuildDetail(cbf, efCause.getProjectName());
         details.setFlowRuntimeId(efCause.getFlowRuntimeId());
-        details.setAssociationType(BuildAssociationType.TRIGGERED_BY_FLOW);
-        details.setBuildTriggerSource(BuildTriggerSource.FLOW);
+        details.setAssociationType(BuildAssociationType.TRIGGERED_BY_CD);
+        details.setBuildTriggerSource(BuildTriggerSource.CD);
 
         if (!efCause.getStageName().equals("null")) {
           details.setStageName(efCause.getStageName());
@@ -206,8 +206,8 @@ public class ElectricFlowBuildWatcher extends RunListener<Run> {
           cause.getProjectName(),
           cause.getReleaseName(),
           cause.getStageName(),
-          BuildTriggerSource.FLOW,
-          BuildAssociationType.TRIGGERED_BY_FLOW
+          BuildTriggerSource.CD,
+          BuildAssociationType.TRIGGERED_BY_CD
       );
     }
   }

--- a/src/main/java/org/jenkinsci/plugins/electricflow/models/CIBuildDetail.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/models/CIBuildDetail.java
@@ -116,6 +116,7 @@ public class CIBuildDetail {
 
   public String getBuildTriggerSource() {
     switch (this.buildTriggerSource) {
+      case CD:
       case FLOW:
         // return "Flow"
         return "CD";
@@ -134,6 +135,7 @@ public class CIBuildDetail {
     switch (this.associationType) {
       case ATTACHED:
         return "attached";
+      case TRIGGERED_BY_CD:
       case TRIGGERED_BY_FLOW:
         // return "triggeredByFlow";
         return "triggeredByCD";


### PR DESCRIPTION
In https://github.com/jenkinsci/electricflow-plugin/pull/170 we added new enum values, but we forgot to update the code to actually use the new values instead of the old values.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

CC @horodchukanton @justnoxx 
