### PR TITLE
[NTVEPLUGIN-450] Fix item context in Credentials dropdowns

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/electricflow/Credential.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/Credential.java
@@ -4,6 +4,7 @@ import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCreden
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.SchemeRequirement;
@@ -16,6 +17,7 @@ import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 import java.util.Collections;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class Credential extends AbstractDescribableImpl<Credential> {
@@ -72,20 +74,22 @@ public class Credential extends AbstractDescribableImpl<Credential> {
   @Extension
   public static class DescriptorImpl extends Descriptor<Credential> {
 
-    public static ListBoxModel doFillCredentialIdItems(Item item) {
-      if (item == null || !item.hasPermission(Item.CONFIGURE)) {
-        return new ListBoxModel();
+    public static ListBoxModel doFillCredentialIdItems(@AncestorInPath Item item) {
+      
+      if (item == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        return new StandardListBoxModel();
       }
-      if (!item.hasPermission(Item.EXTENDED_READ)
+      if (item != null 
+          && !item.hasPermission(Item.EXTENDED_READ) /*implied by Item.CONFIGURE*/ 
           && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
-        return new ListBoxModel();
+        return new StandardListBoxModel();
       }
 
       return new StandardUsernameListBoxModel()
           .includeEmptyValue()
           .includeMatchingAs(
               ACL.SYSTEM,
-              Jenkins.get(),
+              item,
               StandardUsernamePasswordCredentials.class,
               Collections.emptyList(),
               CredentialsMatchers.always());

--- a/src/test/java/org/jenkinsci/plugins/electricflow/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/electricflow/CredentialsTest.java
@@ -1,0 +1,85 @@
+package org.jenkinsci.plugins.electricflow;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.FreeStyleProject;
+import hudson.util.ListBoxModel;
+import org.hamcrest.MatcherAssert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+public class CredentialsTest {
+
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void testFillCredentialsItems() throws Exception {
+
+        // When no credentials, assert that there is at least one value, the empty value
+        Folder folder = jenkinsRule.jenkins.createProject(Folder.class, "folder");
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "freestyle");
+
+        MatcherAssert.assertThat(Credential.DescriptorImpl.doFillCredentialIdItems(null), hasSize(1));
+        MatcherAssert.assertThat(Credential.DescriptorImpl.doFillCredentialIdItems(folder), hasSize(1));
+        MatcherAssert.assertThat(Credential.DescriptorImpl.doFillCredentialIdItems(job), hasSize(1));
+
+        // System Credentials
+        String systemCredId = "screds";
+        SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(
+            CredentialsScope.SYSTEM, systemCredId, systemCredId, "user", "password"));
+        // Root credentials
+        String globalCredId = "gcreds";
+        SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(
+            CredentialsScope.GLOBAL, globalCredId, globalCredId, "user", "password"));
+        // Folder credentials
+        Iterable<CredentialsStore> stores = CredentialsProvider.lookupStores(folder);
+        CredentialsStore folderStore = null;
+        for (CredentialsStore s : stores) {
+            if (s.getProvider() instanceof FolderCredentialsProvider && s.getContext() == folder) {
+                folderStore = s;
+                break;
+            }
+        }
+        assert folderStore != null;
+        String folderCredId = "fcreds";
+        StandardUsernamePasswordCredentials folderCred = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
+            folderCredId, folderCredId, "user", "password");
+        folderStore.addCredentials(Domain.global(), folderCred);
+        folderStore.save();
+
+        // From Root context
+        // Assert we can see root credentials and system scoped, but not folder credentials
+        ListBoxModel options = Credential.DescriptorImpl.doFillCredentialIdItems(null);
+        MatcherAssert.assertThat(options, hasSize(3));
+        MatcherAssert.assertThat(options.stream().map(option -> option.value).collect(Collectors.toList()),
+            containsInAnyOrder("", globalCredId, systemCredId));
+
+        // From Folder context
+        // Assert we can see root credentials and folder credentials, but not system scoped
+        options = Credential.DescriptorImpl.doFillCredentialIdItems(folder);
+        MatcherAssert.assertThat(options, hasSize(3));
+        MatcherAssert.assertThat(options.stream().map(option -> option.value).collect(Collectors.toList()),
+            containsInAnyOrder("", globalCredId, folderCredId));
+
+        // From Item context
+        // Assert we can see root credentials and folder credentials, but not system scoped
+        options = Credential.DescriptorImpl.doFillCredentialIdItems(job);
+        MatcherAssert.assertThat(options, hasSize(3));
+        MatcherAssert.assertThat(options.stream().map(option -> option.value).collect(Collectors.toList()),
+            containsInAnyOrder("", globalCredId, folderCredId));
+    }
+}


### PR DESCRIPTION
[JENKINS-66958](https://issues.jenkins.io/browse/JENKINS-66958) tracked internally as "NTVEPLUGIN-450". The credentials dropdown was not display Folder scoped credentials although it is actually supported: https://github.com/jenkinsci/electricflow-plugin/blob/electricflow-1.1.24/src/main/java/org/jenkinsci/plugins/electricflow/Credential.java#L46-L54.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue