### PR TITLE
[NTVEPLUGIN-452] Fix override credentials lookup when Sending CiBuild…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,18 @@
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.5.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>3.5.13</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/electricflow/event/ElectricFlowBuildWatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/event/ElectricFlowBuildWatcher.java
@@ -122,6 +122,7 @@ public class ElectricFlowBuildWatcher extends RunListener<Run> {
           electricFlowClient = ElectricFlowClientFactory.getElectricFlowClient(
             tc.getConfigurationName(),
             cdPBABuildDetails.getOverriddenCredential(),
+            run,
             null,
             true
           );


### PR DESCRIPTION
…Data

Pass the `Run` context when sending CiBuildData with overridden credentials.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue