### PR TITLE
Add build axis with recent Core including the Guava bump

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,4 +7,7 @@ buildPlugin(configurations: [
 
          // Sanity on the minimum required Jenkins version on Windows
          [ platform: "windows", jdk: "8"],
+
+         // More recent with Guava & Guice bumps, only Linux
+         [ platform: "linux", jdk: "8", jenkins: '2.324', javaLevel: "8" ]
 ])


### PR DESCRIPTION
Guava got bumped from 11 to 30+ past 2.320+.

So while this addition will not catch everything, if this does not blow up that's still good to have/know.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
