### PR TITLE
Use owasp-java-html-sanitizer through antisamy-markup-sanitizer-plugin

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Pconsume-incrementals

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--Pconsume-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
 <!--    <jenkins.version>2.190.3</jenkins.version>-->
-    <jenkins.version>2.235.4</jenkins.version>
+    <jenkins.version>2.277.4</jenkins.version>
     <java.level>8</java.level>
     <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
@@ -104,15 +104,9 @@
       <version>1.2.2</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
-      <artifactId>owasp-java-html-sanitizer</artifactId>
-      <version>[20211018.2,)</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>antisamy-markup-formatter</artifactId>
+      <version>136.v94fb_413c7721</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
       <artifactId>owasp-java-html-sanitizer</artifactId>
-      <version>[20211018.1,)</version>
+      <version>[20211018.2,)</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>antisamy-markup-formatter</artifactId>
-      <version>136.v94fb_413c7721</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/test/java/org/jenkinsci/plugins/electricflow/HtmlSanitizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/electricflow/HtmlSanitizerTest.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.electricflow;
+
+import org.jenkinsci.plugins.electricflow.ui.HtmlUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HtmlSanitizerTest {
+
+    @Test
+    public void simpleSanitize() {
+        String sanitized = HtmlUtils.getHtmlPolicy().sanitize("<html><head><script>alert('paco');</script></head><body><h1>Hi</h1></body></html>");
+        Assert.assertNotNull("sanitized string should not be null", sanitized);
+        Assert.assertEquals("The sanitized html is not the one expected", "Hi", sanitized);
+    }
+
+    @Test
+    public void sanitizeAllowedElements() {
+        String sanitized = HtmlUtils.getHtmlPolicy().sanitize("<html><head><script>alert('paco');</script></head><body><h3>hi</h3><b>this is right</b></body></html>");
+        Assert.assertNotNull("sanitized string should not be null", sanitized);
+        Assert.assertEquals("The sanitized html is not the one expected", "<h3>hi</h3><b>this is right</b>", sanitized);
+    }
+}


### PR DESCRIPTION
That library depends on Guava which is a library provided by core, by not using it directly but instead via this plugin extra guanrantees for compatibility are achieved. Because the probabilities of antisamy-markup-formatter plugin to detect some sort of incompatibility between owasp-java-sanitizer and jenkins core are bigger as is related to the main functionality provided.

I have also added a small test to smoke the HTML sanitization, so in the future, compatibility can be tested by using `-Djenkins.version` 

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
