### PR TITLE
Fix visual regression on REST API call UI

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/electricflow/CloudBeesFlowCallRestApiStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/electricflow/CloudBeesFlowCallRestApiStep/config.jelly
@@ -24,7 +24,7 @@ All rights reserved.
             Key:
             <f:textbox field="key" style="width: 40%"/>
             Value:
-            <f:textbox field="value" style="width: 40%; position: absolute"/>
+            <f:textbox field="value" style="width: 40%;"/>
             <div align="right">
                 <f:repeatableDeleteButton/>
             </div>

--- a/src/main/resources/org/jenkinsci/plugins/electricflow/CloudBeesFlowCallRestApiStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/electricflow/CloudBeesFlowCallRestApiStep/config.jelly
@@ -21,10 +21,10 @@ All rights reserved.
     </f:entry>
     <f:entry field="parameters" title="Parameters">
         <f:repeatable field="parameters">
-            Key:
-            <f:textbox field="key" style="width: 40%"/>
-            Value:
-            <f:textbox field="value" style="width: 40%;"/>
+            <fieldset style="display: flex; align-items: baseline; gap: 1rem; border: none;">
+                <div>${%Key}</div><f:textbox field="key" style="flex-basis: 40%"/>
+                <div>${%Value}</div><f:textbox field="value" style="flex-basis: 40%"/>
+            </fieldset>
             <div align="right">
                 <f:repeatableDeleteButton/>
             </div>

--- a/src/main/resources/org/jenkinsci/plugins/electricflow/ElectricFlowGenericRestApi/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/electricflow/ElectricFlowGenericRestApi/config.jelly
@@ -21,10 +21,10 @@ All rights reserved.
   </f:entry>
   <f:entry field="parameters" title="Parameters">
     <f:repeatable field="parameters">
-          Key:
-          <f:textbox field="key" style="width: 40%"/>
-          Value:
-          <f:textbox field="value" style="width: 40%"/>
+        <fieldset style="display: flex; align-items: baseline; gap: 1rem; border: none;">
+            <div>${%Key}</div><f:textbox field="key" style="flex-basis: 40%"/>
+            <div>${%Value}</div><f:textbox field="value" style="flex-basis: 40%"/>
+        </fieldset>
         <div align="right">
             <f:repeatableDeleteButton/>
         </div>

--- a/src/main/resources/org/jenkinsci/plugins/electricflow/ElectricFlowGenericRestApi/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/electricflow/ElectricFlowGenericRestApi/config.jelly
@@ -24,7 +24,7 @@ All rights reserved.
           Key:
           <f:textbox field="key" style="width: 40%"/>
           Value:
-          <f:textbox field="value" style="width: 40%; position: absolute"/>
+          <f:textbox field="value" style="width: 40%"/>
         <div align="right">
             <f:repeatableDeleteButton/>
         </div>


### PR DESCRIPTION
The previous use of absolute positioning for rest call params was not compatible with the new UI improvements on Core, resulting in a visual regression:
![electric1](https://user-images.githubusercontent.com/642531/154857414-26884d66-d399-4bc3-a554-cd3b3012f0f5.jpg)
 I have removed the absolute positioning in favor of `flex` CSS properties to achieve the same UI as before.
![electric2](https://user-images.githubusercontent.com/642531/154857461-0313379f-e4d8-447a-8ae3-c74df85f97ca.jpg)
Note this is a quick fix, not intended to be a canonical rewrite of the affected UI parts

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
