### PR TITLE
[chore] Remove unused sshd-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,6 @@
       <version>3.3.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-core</artifactId>
-      <version>1.7.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
       <version>2.10.3</version>


### PR DESCRIPTION
That dependency is un-necessary as far as I can tell. 
It was added as part of https://github.com/jenkinsci/electricflow-plugin/commit/e78f32ee6588cf6b78f23edbb1603cef0a5789e8 but not sure why.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue