### PR TITLE
Update SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>


### PR DESCRIPTION
Fixes the following build warning from recent versions of `maven-hpi-plugin`:

```
[WARNING] <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection> is invalid because git:// URLs are deprecated. Replace it with <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>. In the future this warning will be changed to an error and will break the build.
```