### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,5 +9,5 @@ buildPlugin(configurations: [
          [ platform: "windows", jdk: "8"],
 
          // More recent with Guava & Guice bumps, only Linux
-         [ platform: "linux", jdk: "8", jenkins: '2.324', javaLevel: "8" ]
+         [ platform: "linux", jdk: "8", jenkins: '2.324' ]
 ])


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.