### PR TITLE
[CDRO-946] Fixing the buggy checkmark icon for pipeline/procedure with parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ You can use the following workarounds instead of the **Add** button to help you 
 ## Version 1.1.38 (TBD)
 
 - Update **Stage Option** tool tips for **Run Pipeline** procedure.
+- Fix issue in **Post Build Action - Run Procedure** where the dropdown icon for the **config** field would shift when choosing **Procedure Name**.
 
 ## Version 1.1.37 (July 26, 2024)
 

--- a/src/main/resources/org/jenkinsci/plugins/electricflow/ElectricFlowRunProcedure/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/electricflow/ElectricFlowRunProcedure/config.jelly
@@ -109,7 +109,7 @@ All rights reserved.
                             var el = document.createElement("div");
                             el.innerHTML = "&lt;br&gt;&lt;b&gt;Procedure Parameters&lt;/b&gt;";
                             el.className = "_ef_rp_row";
-                            var div = document.getElementById("ef_rp_procedureName");
+                            var div = document.getElementById("ef_rp_procedureName").closest('.jenkins-select');
                             div = cbcd_insertAfter(div, el);
                             parameters.forEach(function (elem) {
                                 var el_param = document.createElement("div");


### PR DESCRIPTION
moving the divs to create after the jenkins-select div, which was the cause of the issue.

This PR moves the div creation a step above currently created. i.e. the .jenkins-select div.
The related JIRA is ([CDRO-946](https://cloudbees.atlassian.net/browse/CDRO-946))

### Testing done

This was tested with a jenkins docker and the changes in the plugin, which was deployed locally.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira

