### PR TITLE
Set explicit Content-Type: application/json for CloudBees CD REST calls in the Jenkins electricflow-plugin to avoid Jetty 12.1+ consuming request bodies as form data (CDRO-13314).

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowClient.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowClient.java
@@ -324,6 +324,8 @@ public class ElectricFlowClient {
         conn.setUseCaches(false);
         conn.setDoInput(true);
         conn.setDoOutput(true);
+        // Set Content-Type to JSON
+        conn.setRequestProperty("Content-Type", "application/json");
 
         if (ignoreSsl && conn instanceof HttpsURLConnection) {
             HttpsURLConnection sslConn = (HttpsURLConnection) conn;


### PR DESCRIPTION
**Summary**
This change updates the Jenkins electricflow-plugin to explicitly set the HTTP Content-Type header to application/json for REST API calls to CloudBees CD.

**Background / Problem**
The Jenkins [GitHub - jenkinsci/electricflow-plugin](https://github.com/jenkinsci/electricflow-plugin) currently uses HttpURLConnection with setDoOutput(true) to send REST requests to CloudBees CD but does not explicitly set a Content-Type header. In that case, the JVM defaults the header to:

`Content-Type: application/x-www-form-urlencoded`
However, the plugin actually sends JSON payloads.

With CloudBees CD 26.06 running on Jetty 12.1+ (Servlet 6.1), this mismatch becomes a breaking issue. For POST requests with `Content-Type: application/x-www-form-urlencoded`, the servlet container must parse the body as form data, which consumes the input stream. When the application code later tries to read the body as JSON, the stream is already exhausted and all JSON parameters appear as null.

This affects REST calls made by the Jenkins plugin (for example, `setCiBuildDetail`) when targeting a CD instance running on Jetty 12.1+.

**Jetty / Servlet 6.1 Behavior**
In Jetty 12.0.x there was an internal guard in extractContentParameters():

- Jetty 12.0.23:

`if (contentLength != 0 && _inputState == ServletContextRequest.INPUT_NONE)`
- Jetty 12.1.7:

`if (contentLength != 0)`
Jetty 12.1 removed the `_inputState` check to align strictly with the Servlet 6.1 specification, which mandates that for `application/x-www-form-urlencoded` POSTs the container parses the body as form data. Because the plugin incorrectly declares `application/x-www-form-urlencoded` while sending JSON, Jetty now (correctly) parses and consumes the body as form data, leaving nothing for JSON parsing.

**Change Implemented**
In the plugin’s HTTP client code, we now explicitly set the `Content-Type` header to `application/json` for CloudBees CD REST calls.

Key location:

ElectricFlowClient.java around line 318
[electricflow-plugin/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowClient.java at 49ff42fe668eb1fc82476f10b10bda13db573685 · jenkinsci/electricflow-plugin](https://github.com/jenkinsci/electricflow-plugin/blob/49ff42fe668eb1fc82476f10b10bda13db573685/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowClient.java#L318)

Effects:

All outbound REST calls from the Jenkins electricflow-plugin now use:


`Content-Type: application/json`
The servlet container no longer interprets the body as URL‑encoded form data and therefore does not consume the input stream before JSON parsing.

Server-side behavior in CloudBees CD is unchanged; the fix is fully on the client side and brings the plugin into HTTP/Servlet spec compliance.

**Impact**
- Prevents REST calls (e.g. `setCiBuildDetail`) from failing with `null` parameters against CloudBees CD 26.06+ on Jetty 12.1+.
- Aligns the Jenkins plugin with other CD clients (`ectool`, `ec-perl`), which already send JSON with the correct Content-Type.
- No breaking changes or server‑side workarounds; this is a client‑side hardening change.

### Testing done
Testing is done with the bringing a CDRO server up and testing it with the older plugin version <1.1.41 ( which sets the Content-Type as default  application/x-www-form-urlencoded) 

<img width="2530" height="963" alt="image" src="https://github.com/user-attachments/assets/cf56e133-b695-462b-9eef-73e1840763ac" />

and then installing the new plugin version which sets the Content-Type as application json. 

<img width="2529" height="779" alt="image" src="https://github.com/user-attachments/assets/44dce7a9-2904-4342-8b57-88cd1fa83eb3" />

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
