### PR TITLE
Always show build summary even when attachCIBuildDetails fails

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisher.java
@@ -224,11 +224,14 @@ public class ElectricFlowPipelinePublisher extends Recorder implements SimpleBui
                         null,
                         BuildTriggerSource.CI,
                         BuildAssociationType.TRIGGERED_BY_CI);
-                run.addAction(new SummaryTextAction(run, summaryHtml));
             } catch (RuntimeException exception) {
                 log.info("Can't attach CIBuildData to the pipeline run: " + exception.getMessage());
             }
 
+            // Always show the build summary, regardless of whether attaching CI build details
+            // succeeded. Attaching CIBuildData can fail (e.g. 403 when the CD user lacks modify
+            // privilege on the runtime) and must not suppress the summary.
+            run.addAction(new SummaryTextAction(run, summaryHtml));
             run.save();
             logger.println("Pipeline triggered. Response JSON: " + formatJsonOutput(pipelineResult));
 

--- a/src/test/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisherSummaryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisherSummaryTest.java
@@ -73,8 +73,8 @@ public class ElectricFlowPipelinePublisherSummaryTest {
 
         try (MockedStatic<ElectricFlowClientFactory> factoryMock = mockStatic(ElectricFlowClientFactory.class)) {
             factoryMock
-                    .when(() -> ElectricFlowClientFactory.getElectricFlowClient(
-                            anyString(), any(), any(Run.class), any()))
+                    .when(() ->
+                            ElectricFlowClientFactory.getElectricFlowClient(anyString(), any(), any(Run.class), any()))
                     .thenReturn(mockClient);
 
             publisher.perform(build, build.getWorkspace(), jenkinsRule.createLocalLauncher(), TaskListener.NULL);

--- a/src/test/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisherSummaryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/electricflow/ElectricFlowPipelinePublisherSummaryTest.java
@@ -1,0 +1,90 @@
+package org.jenkinsci.plugins.electricflow;
+
+import static org.jenkinsci.plugins.electricflow.test.Utils.createConfigurationInJenkinsRule;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.util.Collections;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.electricflow.factories.ElectricFlowClientFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.MockedStatic;
+
+/**
+ * Regression test for SECO-5550 / the behavior change introduced in PR #408.
+ *
+ * <p>PR #408 moved {@code run.addAction(new SummaryTextAction(...))} inside the try block that wraps
+ * {@code attachCIBuildDetails}. As a side effect, whenever attaching the CI build details fails
+ * (e.g. a 403 AccessDenied when the CD user lacks modify privilege on the runtime), the build
+ * summary was silently suppressed. This test pins the corrected behavior: the summary must always be
+ * attached even when {@code attachCIBuildDetails} throws.
+ */
+public class ElectricFlowPipelinePublisherSummaryTest {
+
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void summaryIsAddedEvenWhenAttachCIBuildDetailsFails() throws Exception {
+        String configurationName = Utils.CONFIG_SKIP_CHECK_CONNECTION;
+        createConfigurationInJenkinsRule(jenkinsRule, configurationName);
+
+        // A pipeline run response that the publisher can parse for flowRuntimeId / projectName.
+        String pipelineRunResponse = new JSONObject()
+                .element(
+                        "flowRuntime",
+                        new JSONObject()
+                                .element("pipelineId", "pipeline-id")
+                                .element("flowRuntimeId", "flow-runtime-id")
+                                .element("projectName", "CloudBees"))
+                .toString();
+
+        ElectricFlowClient mockClient = mock(ElectricFlowClient.class);
+        when(mockClient.getElectricFlowUrl()).thenReturn("http://localhost");
+        when(mockClient.getPipelineId(anyString(), anyString())).thenReturn("pipeline-id");
+        when(mockClient.getPipelineFormalParameters(anyString())).thenReturn(Collections.emptyList());
+        when(mockClient.runPipeline(any(), any(), any(), any(), any(), any())).thenReturn(pipelineRunResponse);
+        // Simulate the 403 AccessDenied that CD/RO returns when the user lacks modify privilege.
+        when(mockClient.attachCIBuildDetails(any()))
+                .thenThrow(new RuntimeException(
+                        "Failed : HTTP error code : 403, Forbidden, does not have modify privilege on flowRuntime"));
+
+        ElectricFlowPipelinePublisher publisher = new ElectricFlowPipelinePublisher();
+        publisher.setConfiguration(configurationName);
+        publisher.setProjectName("CloudBees");
+        publisher.setPipelineName("JenkinsTestPipeline");
+
+        // An empty build gives us a real Run (with a workspace) to drive perform() on the test
+        // thread, so the static factory mock below stays in effect for the publisher's logic.
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
+
+        try (MockedStatic<ElectricFlowClientFactory> factoryMock = mockStatic(ElectricFlowClientFactory.class)) {
+            factoryMock
+                    .when(() -> ElectricFlowClientFactory.getElectricFlowClient(
+                            anyString(), any(), any(Run.class), any()))
+                    .thenReturn(mockClient);
+
+            publisher.perform(build, build.getWorkspace(), jenkinsRule.createLocalLauncher(), TaskListener.NULL);
+        }
+
+        // The attach failed, but the build must not be marked as a failure because of it ...
+        assertEquals(Result.SUCCESS, build.getResult());
+        // ... and the summary must still be present on the run.
+        assertNotNull(
+                "SummaryTextAction must be added even when attachCIBuildDetails throws",
+                build.getAction(SummaryTextAction.class));
+    }
+}


### PR DESCRIPTION
  Fixes a regression from #408 where the Jenkins build summary ("CloudBees CD Run Pipeline" panel) silently disappears when `attachCIBuildDetails` throws — e.g. a 403 when the CD user lacks `modify` privilege on the pipeline runtime. PR #408
  moved `run.addAction(new SummaryTextAction(...))` inside the try block, so a handled attach failure now also suppresses the unrelated summary panel. This moves the call back out of the try/catch so the summary always renders, keeping #408's
  polling-loop cleanup intact.

  ### Testing done

  - Added `ElectricFlowPipelinePublisherSummaryTest`, which mocks `attachCIBuildDetails` to throw a 403 and asserts the build stays SUCCESS and a `SummaryTextAction` is attached. Verified it fails against the pre-fix code and passes after the
  fix, so it exercises the changed lines.
  - Manually reproduced on a live CD/RO + Jenkins setup using a CD user with `modify` denied on the pipeline runtime. Before the fix the build succeeded but the summary panel was missing; after the fix the same run succeeded and the panel
  rendered, while the 403 was still logged. Screenshots of the build Status page before and after are attached below.

  _Before:_ 
<img width="1719" height="435" alt="run4" src="https://github.com/user-attachments/assets/07026745-acae-494f-8eb9-847b4ec6f5c3" />

  <!-- attach the old-plugin run: SUCCESS, no "CloudBees CD Run Pipeline" panel -->

  _After:_
<img width="1304" height="504" alt="Screenshot 2026-06-24 at 6 14 17 PM" src="https://github.com/user-attachments/assets/7b25114a-1c99-4b45-bdb5-7fbe002578a9" />

  <!-- attach the patched-plugin run #6: SUCCESS, panel present -->

  ### Submitter checklist
  - [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
  - [x] Ensure that the pull request title represents the desired changelog entry
  - [x] Please describe what you did
  - [x] Link to relevant issues in GitHub or Jira
  - [x] Link to relevant pull requests, esp. upstream and downstream changes
  - [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed