### PR TITLE
Remove usages of Commons Lang 2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowTriggerRelease.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/ElectricFlowTriggerRelease.java
@@ -43,7 +43,6 @@ import java.util.concurrent.TimeUnit;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jenkinsci.Symbol;
@@ -128,7 +127,7 @@ public class ElectricFlowTriggerRelease extends Recorder implements SimpleBuildS
                 this.setReleaseName(release.getString("releaseName"));
             }
         }
-        if (!StringUtils.isEmpty(stageOptions)) {
+        if (!(stageOptions == null || stageOptions.isEmpty())) {
             if (stageOptions.equalsIgnoreCase("runAllStages")) {
                 stagesToRun.addAll(getAllStagesForRelease(efClient));
                 this.startingStage = stagesToRun.get(0);

--- a/src/main/java/org/jenkinsci/plugins/electricflow/triggerRelease/TriggerReleaseIsStagesChecked.java
+++ b/src/main/java/org/jenkinsci/plugins/electricflow/triggerRelease/TriggerReleaseIsStagesChecked.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.electricflow.triggerRelease;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
@@ -19,7 +18,7 @@ public class TriggerReleaseIsStagesChecked {
 
     public static String isStagesChecked(String parameters, String startingStage, Object stageOptions) {
         String checkedVal = (String) stageOptions;
-        if (StringUtils.isEmpty((String) stageOptions)) {
+        if (checkedVal == null || checkedVal.isEmpty()) {
             if (!startingStage.isEmpty()) {
                 checkedVal = "startingStage";
             } else {


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this
functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- `ElectricFlowTriggerRelease` and `TriggerReleaseIsStagesChecked`: the two `StringUtils.isEmpty`
  calls become plain null plus `isEmpty()` checks. No dependency was added.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer and this plugin is on `5.2102.v5f5fe09fccf1`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
